### PR TITLE
Switch from Fixnum to Integer

### DIFF
--- a/lib/pry-theme/color.rb
+++ b/lib/pry-theme/color.rb
@@ -394,8 +394,8 @@ module PryTheme
       case (color_id = cast_color(layer))
       when String
         return color_id if colors.has_key?(color_id)
-      when Fixnum
-        color_id = find_from_fixnum(color_id)
+      when Integer
+        color_id = find_from_integer(color_id)
         return color_id if color_id
       when false
         return color_id

--- a/lib/pry-theme/colors/color16.rb
+++ b/lib/pry-theme/colors/color16.rb
@@ -23,7 +23,7 @@ module PryTheme
       []
     end
 
-    def find_from_fixnum(color_id)
+    def find_from_integer(color_id)
       sorted_colors.each_with_index.to_a.rassoc(color_id).first.first
     end
 

--- a/lib/pry-theme/colors/color256.rb
+++ b/lib/pry-theme/colors/color256.rb
@@ -21,7 +21,7 @@ module PryTheme
       ['48', '5', background]
     end
 
-    def find_from_fixnum(color_id)
+    def find_from_integer(color_id)
       pair = colors.find { |*term| term.first.flatten.include?(color_id) }
       pair.first if pair
     end

--- a/lib/pry-theme/colors/color8.rb
+++ b/lib/pry-theme/colors/color8.rb
@@ -19,7 +19,7 @@ module PryTheme
       [background]
     end
 
-    def find_from_fixnum(color_id)
+    def find_from_integer(color_id)
       sorted_colors.each_with_index.to_a.rassoc(color_id).first.first
     end
 

--- a/lib/pry-theme/declaration.rb
+++ b/lib/pry-theme/declaration.rb
@@ -98,7 +98,7 @@ module PryTheme
         if decl_has_bg_key?
           @bg = f[:bg]
           @color_decl.shift
-        elsif f.is_a?(String) || f.is_a?(Fixnum)
+        elsif f.is_a?(String) || f.is_a?(Integer)
           @fg = @color_decl.shift
         else
           build_effects
@@ -112,7 +112,7 @@ module PryTheme
 
       def decl_contains_rgb?
         l = @color_decl.last
-        l.size == 3 && l.all? { |decl| decl.is_a?(Fixnum) }
+        l.size == 3 && l.all? { |decl| decl.is_a?(Integer) }
       end
 
     end

--- a/lib/pry-theme/rgb.rb
+++ b/lib/pry-theme/rgb.rb
@@ -174,7 +174,7 @@ module PryTheme
     # @return [void]
     def validate_array(ary)
       correct_size = ary.size.equal?(3)
-      correct_vals = ary.all?{ |val| val.is_a?(Fixnum) && val.between?(0, 255) }
+      correct_vals = ary.all?{ |val| val.is_a?(Integer) && val.between?(0, 255) }
       return true if correct_size && correct_vals
       raise ArgumentError,
             %|invalid value for PryTheme::RGB#validate_array(): "#{ ary }"|

--- a/lib/pry-theme/term.rb
+++ b/lib/pry-theme/term.rb
@@ -37,9 +37,9 @@ module PryTheme
     #   at all
     # @return [void]
     def validate_attrs(value, color_model)
-      fixnums = value.is_a?(Fixnum) && color_model.is_a?(Fixnum)
+      integers = value.is_a?(Integer) && color_model.is_a?(Integer)
       correct_term =
-        if fixnums
+        if integers
           case color_model
           when 256 then value.between?(0, 255)
           when 16  then value.between?(0, 15)
@@ -50,9 +50,9 @@ module PryTheme
           end
         end
 
-      return true if fixnums && correct_term
+      return true if integers && correct_term
 
-      unless fixnums
+      unless integers
         raise TypeError, "can't convert #{ value.class } into PryTheme::TERM"
       end
 

--- a/spec/term_spec.rb
+++ b/spec/term_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 describe PryTheme::TERM do
   TERM = PryTheme::TERM
 
-  it "represents itself as Fixnum" do
+  it "represents itself as Integer" do
     TERM.new(23).to_i.should == 23
   end
 


### PR DESCRIPTION
Use Integer instead wherever Fixnum is used to avoid Ruby 2.4+ warnings relating to Fixnum and Bignum being unified into Integer.