### PR TITLE
Modifying deprecated code.

### DIFF
--- a/lib/pry-theme/theme_list.rb
+++ b/lib/pry-theme/theme_list.rb
@@ -30,7 +30,7 @@ module PryTheme
     end
 
     def activate_theme_intelligently
-      if Pry::Helpers::BaseHelpers.windows?
+      if Pry::Helpers::Platform.windows?
         activate_theme('pry-classic-16')
       else
         case PryTheme.tput_colors


### PR DESCRIPTION
@kyrylo 
I found code which is using deprecated.

```
❯ bin/console
/app/to/path/vendor/bundle/gems/pry-theme-1.2.0/lib/pry-theme/theme_list.rb:33: warning: method BaseHelpers#windows? is deprecated. Use Pry:Helpers::Platform.windows? instead
```

Please merge if possible.