### PR TITLE
Cleanup Ruby warnings 

### DIFF
--- a/lib/pry-theme/declaration.rb
+++ b/lib/pry-theme/declaration.rb
@@ -22,6 +22,8 @@ module PryTheme
         @color_class = PryTheme.const_get(:"Color#{ color_model }")
         @effects     = {}
         @parsed      = false
+        @fg          = nil
+        @bg          = nil
       end
 
       def parse

--- a/lib/pry-theme/definition.rb
+++ b/lib/pry-theme/definition.rb
@@ -53,7 +53,7 @@ module PryTheme
         :keyword, :method, :predefined_constant, :symbol
       ]
 
-      def_dynamic_methods *ATTRS
+      def_dynamic_methods(*ATTRS)
 
       def initialize(color_model, &block)
         @color_model = color_model
@@ -82,7 +82,7 @@ module PryTheme
 
         ATTRS = [:self_, :char, :content, :delimiter, :escape]
 
-        def_dynamic_methods *ATTRS
+        def_dynamic_methods(*ATTRS)
 
         def initialize(color_model, &block)
           @color_model = color_model
@@ -94,7 +94,7 @@ module PryTheme
       class Regexp < Compound
         ATTRS = [:modifier]
 
-        def_dynamic_methods *ATTRS
+        def_dynamic_methods(*ATTRS)
 
         def initialize(color_model, &block)
           @color_model = color_model

--- a/lib/pry-theme/theme.rb
+++ b/lib/pry-theme/theme.rb
@@ -37,6 +37,7 @@ module PryTheme
       @authors = [{ :name => @config[:author] }]
       @default_author = true
       @active = false
+      @definition = nil
 
       validate_config
 

--- a/lib/pry-theme/theme_list.rb
+++ b/lib/pry-theme/theme_list.rb
@@ -20,7 +20,7 @@ module PryTheme
     end
 
     def activate_theme(name)
-      theme = themes.find { |theme| theme.name == name }
+      theme = themes.find { |t| t.name == name }
 
       if theme
         current_theme.disable if current_theme

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,10 +1,19 @@
 require 'bundler/setup'
-require 'pry/test/helper'
+
+require 'pry'
+if Pry::VERSION < '0.11'
+  require 'pry/test/helper'
+else
+  require 'pry/testable'
+  include Pry::Testable
+end
 
 Bundler.require :default, :test
 
-Pry.config.theme = nil
+Pry.config.color = false
+Pry.config.hooks = Pry::Hooks.new
 Pry.config.pager = false
+Pry.config.theme = nil
 
 puts(
   "Ruby: #{RUBY_VERSION}; " +


### PR DESCRIPTION
Built on top of #57 

This removes the following Ruby warnings (which appear if you are using pry-theme as part of pry but running with warnings enabled)

- `pry-theme/lib/pry-theme/theme_list.rb:23: warning: shadowing outer local variable - theme`
- `pry-theme/lib/pry-theme/definition.rb:56,85,97: warning: '*' interpreted as argument prefix`
- `pry-theme/lib/pry-theme/theme.rb:97,99: warning: instance variable @definition not initialized`
- `pry-theme/lib/pry-theme/declaration.rb:45: warning: instance variable @fg not initialized`
- `pry-theme/lib/pry-theme/declaration.rb:46: warning: instance variable @bg not initialized`
