### PR TITLE
Define `windows?` method

### DIFF
--- a/lib/pry-theme/commands.rb
+++ b/lib/pry-theme/commands.rb
@@ -232,6 +232,10 @@ module PryTheme
       JSON.parse(response.body)
     end
 
+    def windows?
+      (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+    end
+
     def install_theme(args)
       args.each { |theme|
         output.puts %|Installing "#{ theme }" from Pry Theme Collection...|


### PR DESCRIPTION
# Summary

Adds `windows?` method.

# Details

On my MacOS; I got an error when I type `pry-theme install ocean` in pry session.

```
[1] pry(main)> pry-theme install ocean
Installing "ocean" from Pry Theme Collection...
NoMethodError: undefined method `windows?' for #<PryTheme::Command::PryTheme:0x00007fc334a04188>
from /Users/my_user_name/.anyenv/envs/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/pry-theme-1.3.0/lib/pry-theme/commands.rb:230:in `json_body'
```

I find `windows?` method in `lib/pry-theme/commands.rb`. but could not found in anywhere.

# test?

I couldn't write rspec test. I couldn't understand the code base to writing test. sorry...

# Link

* [How can I find which operating system my Ruby program is running on? - Stack Overflow](https://stackoverflow.com/questions/170956/how-can-i-find-which-operating-system-my-ruby-program-is-running-on)