### PR TITLE
Update `windows?` method to Pry helper method

### DIFF
--- a/lib/pry-theme/commands.rb
+++ b/lib/pry-theme/commands.rb
@@ -227,13 +227,9 @@ module PryTheme
       uri = URI.parse(address)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if windows?
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if Pry::Helpers::Platform.windows?
       response = http.request(Net::HTTP::Get.new(uri.request_uri))
       JSON.parse(response.body)
-    end
-
-    def windows?
-      Pry::Helpers::Platform.windows?
     end
 
     def install_theme(args)

--- a/lib/pry-theme/commands.rb
+++ b/lib/pry-theme/commands.rb
@@ -233,7 +233,7 @@ module PryTheme
     end
 
     def windows?
-      (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+      Pry::Helpers::Platform.windows?
     end
 
     def install_theme(args)


### PR DESCRIPTION
# Summary

Continue on #61 : "[We should use Pry::Helpers::Platform.windows? instead.](https://github.com/kyrylo/pry-theme/pull/61#issuecomment-675441835)"

Update `windows?` method.